### PR TITLE
fix service test failing on non linux platforms

### DIFF
--- a/resource/service_test.go
+++ b/resource/service_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package resource
 
 import (


### PR DESCRIPTION
Tests were failing on Mac because service.go has a build tag for linux. Do the same for the test file that depends on it.
I was getting: resource/service_test.go:25: undefined: Service